### PR TITLE
Feature/ed25519 util

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -92,6 +92,15 @@
         }
       },
       {
+        "package": "TweetNacl",
+        "repositoryURL": "https://github.com/bitmark-inc/tweetnacl-swiftwrap.git",
+        "state": {
+          "branch": null,
+          "revision": "f8fd111642bf2336b11ef9ea828510693106e954",
+          "version": "1.1.0"
+        }
+      },
+      {
         "package": "web3.swift",
         "repositoryURL": "https://github.com/argentlabs/web3.swift",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -22,11 +22,12 @@ let package = Package(
         .package(name:"jwt-kit", url: "https://github.com/vapor/jwt-kit.git", from: "4.0.0"),
         .package(name:"web3.swift", url: "https://github.com/argentlabs/web3.swift", from:"0.8.1"),
         .package(name:"secp256k1", url: "https://github.com/Boilertalk/secp256k1.swift", from: "0.1.0"),
+        .package(name: "TweetNacl", url: "https://github.com/bitmark-inc/tweetnacl-swiftwrap.git", from: "1.0.0")
     ],
     targets: [
         .target(
             name: "TorusUtils",
-            dependencies: ["FetchNodeDetails", "CryptoSwift", "web3.swift", "CryptorECC", "secp256k1", "PMKFoundation", "PromiseKit"]),
+            dependencies: ["FetchNodeDetails", "CryptoSwift", "web3.swift", "CryptorECC", "secp256k1", "PMKFoundation", "PromiseKit", "TweetNacl"]),
         .testTarget(
             name: "TorusUtilsTests",
             dependencies: ["TorusUtils", .product(name: "JWTKit", package: "jwt-kit"), "FetchNodeDetails", "web3.swift", .product(name: "PromiseKit", package: "PromiseKit"), "PMKFoundation", "CryptorECC"]),

--- a/Sources/TorusUtils/Convenience/ED25591.swift
+++ b/Sources/TorusUtils/Convenience/ED25591.swift
@@ -13,7 +13,7 @@ public struct ED25591 {
     /// Returns ED25591 Keypair
     /// - Parameter privateKey: Private key returned from `getTorusKey`
     /// - Returns: Returns a tuple containing an ED25519 secretKey (sk) and publicKey (pk)
-    public static func getED25519Key(privateKey: String) -> throws (sk: String, pk: String) {
+    public static func getED25519Key(privateKey: String) throws ->  (sk: String, pk: String) {
         
         var sk = Data(hex: privateKey).bytes
         

--- a/Sources/TorusUtils/Convenience/ED25591.swift
+++ b/Sources/TorusUtils/Convenience/ED25591.swift
@@ -1,0 +1,35 @@
+//
+//  File.swift
+//  
+//
+//  Created by Eric McGary on 4/8/22.
+//
+
+import Foundation
+import CTweetNacl
+
+public struct ED25591 {
+    
+    /// Returns ED25591 Keypair
+    /// - Parameter privateKey: Private key returned from `getTorusKey`
+    /// - Returns: Returns a tuple containing an ED25519 secretKey (sk) and publicKey (pk)
+    public static func getED25519Key(privateKey: String) -> throws (sk: String, pk: String) {
+        
+        var sk = Data(hex: privateKey).bytes
+        
+        guard sk.count == 32 else {
+            throw TorusError.invalidKeySize
+        }
+        
+        sk.append(contentsOf: [UInt8](repeating: 0, count: 32))
+        var pk = [UInt8](repeating: 0, count: 32)
+        
+        crypto_sign_ed25519_tweet_keypair(&pk, &sk)
+        
+        return(
+            sk: pk.base58EncodedString,
+            pk: sk.base58EncodedString
+        )
+        
+    }
+}

--- a/Sources/TorusUtils/Helpers/Error.swift
+++ b/Sources/TorusUtils/Helpers/Error.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum TorusError: Error{
+public enum TorusError: Error, Equatable {
     case configurationError
     case apiRequestFailed
     case errInResponse(Any)

--- a/Sources/TorusUtils/Helpers/Error.swift
+++ b/Sources/TorusUtils/Helpers/Error.swift
@@ -20,6 +20,7 @@ public enum TorusError: Error{
     case unableToDerive
     case interpolationFailed
     case nodesUnavailable
+    case invalidKeySize
     case runtime(_ msg: String)
     case empty
 }
@@ -55,6 +56,8 @@ extension TorusError: CustomDebugStringConvertible{
                 return ""
             case .runtime(let msg):
                 return msg
+            case .invalidKeySize:
+                return "Invalid key size. Expected 32 bytes"
         }
     }
     

--- a/Tests/TorusUtilsTests/ED25519Tests.swift
+++ b/Tests/TorusUtilsTests/ED25519Tests.swift
@@ -1,0 +1,41 @@
+//
+//  ED25519Tests.swift
+//  
+//
+//  Created by Eric McGary on 4/9/22.
+//
+
+import XCTest
+
+@testable import TorusUtils
+
+class ED25519Tests: XCTestCase {
+
+    func testThatInvalidKeyThrows() throws {
+        
+        var thrownError: Error?
+        
+        XCTAssertThrowsError(try ED25591.getED25519Key(privateKey: "invalid")) {
+            thrownError = $0
+        }
+        
+        XCTAssertTrue(
+            thrownError is TorusError,
+            "Unexpected error type: \(type(of: thrownError))"
+        )
+
+        // Verify that our error is equal to what we expect
+        XCTAssertEqual(thrownError as? TorusError, .invalidKeySize)
+        
+    }
+    
+    func testThatValidKeyReturnsEd25519KeyPair() throws {
+                                                           
+        let keypair = try ED25591.getED25519Key(privateKey: "746869736b65797061697277696c6c67656e6572617465737563636573736675")
+        
+        XCTAssertEqual(keypair.pk, "3KzG2V7hN9ZcqxsNw1xYmjoGjkhAnPHaeA2a5gbjSq9ib8Du3v5DgE1nQCDT9gtNJwhsZYmt9qnVcn1TXfDXjwmE")
+        XCTAssertEqual(keypair.sk, "J9e2xjw84srAeBRrxtM4mDAF3UskupFCecFjFvcXM4G")
+        
+    }
+
+}


### PR DESCRIPTION
Adds a convenience to create an ED25519 keypair with a user's torus key. I thought it would be better to add this functionality here in the torus-utils-swift project, that way it is capable of being used in both the CustomAuth and OpenLogin swift packages.

The only dependency that was brought in is the TweetNaCl Swift wrapper and original C library. If you would rather not have an additional dependency I can just bring that code into the repository and reference the original code base in the code.

The implementation is from the TweetNaCl website here https://tweetnacl.cr.yp.to/software.html.

I was also going to create two additional PRs in the CustomAuth and OpenLogin projects to update the required version of the TorusUtils and add examples of how to use the method to retrieve the keypair and use it to create a Solana Wallet.

If this isn't the right place for this functionality please let me know and I can move appropriately! 