### PR TITLE
fix: edge case prefix04

### DIFF
--- a/Sources/TorusUtils/Extensions/String+Extension.swift
+++ b/Sources/TorusUtils/Extensions/String+Extension.swift
@@ -24,15 +24,15 @@ extension String {
         return hasPrefix("04")
     }
 
-    func add04Prefix() -> String {
-        if !hasPrefix("04") {
+    func add04Prefix(targetLength: Int = 128) -> String {
+        if !hasPrefix("04") && self.count == targetLength{
             return "04" + self
         }
         return self
     }
 
-    func strip04Prefix() -> String {
-        if hasPrefix("04") {
+    func strip04Prefix(targetLength: Int = 130) -> String {
+        if hasPrefix("04") && self.count == targetLength {
             let indexStart = index(startIndex, offsetBy: 2)
             return String(self[indexStart...])
         }

--- a/Sources/TorusUtils/Extensions/String+Extension.swift
+++ b/Sources/TorusUtils/Extensions/String+Extension.swift
@@ -25,7 +25,7 @@ extension String {
     }
 
     func add04Prefix(targetLength: Int = 128) -> String {
-        if !hasPrefix("04") && self.count == targetLength{
+        if self.count == targetLength{
             return "04" + self
         }
         return self

--- a/Torus-utils.podspec
+++ b/Torus-utils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "Torus-utils"
-  spec.version      = "8.1.0"
+  spec.version      = "8.1.2"
   spec.ios.deployment_target  = "13.0"
   spec.summary      = "Retrieve user shares"
   spec.homepage     = "https://github.com/torusresearch/torus-utils-swift"


### PR DESCRIPTION
On edge case when the public key 64bytes (128 char)  is start with 04...
The addPrefix skip adding prefix.
when stripPrefix is called, the public key 04 is striped and only 63 bytes (126 chars) left which made the public key invalid.

Fixing this as patch for v8